### PR TITLE
Update main.c

### DIFF
--- a/main.c
+++ b/main.c
@@ -6,6 +6,7 @@
     Daniel Filho        13677114
     Daniel Umeda        13676541
     Manoel Thomaz       13676392
+	Leonardo Pereira 	9039361
 */
 
 #include <stdlib.h>
@@ -43,7 +44,7 @@ sem_t liberar_deposito_caneta;
 Suposições lógicas para descrição do projeto
     ->  Produtor tem um mini armazém de matéria prima para fabricar uma caneta por vez,
         assim como também as envia uma por vez (não tem armazém de produto pronto na fábrica,
-        apenas de materia prima), pois é o que faz mais sentido (exemplo da fábrica volkswagem em aula).
+        apenas de matéria-prima), pois é o que faz mais sentido (exemplo da fábrica volkswagem em aula).
 
     ->  Se há n canetas disponíveis no depósito e o comprador pedir m canetas, tal que m > n, o depósito envia apenas n canetas
         Pois não há como ser diferente.
@@ -58,11 +59,11 @@ Suposições lógicas para descrição do projeto
 
 /*  RANKS:
 
-        rank 0: função            = criador
-        rank 1: thread_list_ID[1] = Depósito de Matéria Prima
+        rank 0: função            = Criador
+        rank 1: thread_list_ID[1] = Depósito de Matéria-Prima
         rank 2: thread_list_ID[2] = Célula de Fabricação de Canetas
         rank 3: thread_list_ID[3] = Controle
-        rank 4: thread_list_ID[4] = Depósito de canetas
+        rank 4: thread_list_ID[4] = Depósito de Canetas
         rank 5: thread_list_ID[5] = Comprador
 */
 // -------------------------- Funções acessoras --------------------------
@@ -78,35 +79,35 @@ void controle(void)
         {
             pthread_mutex_lock(&acessar_deposito_materiaPrima);
             pthread_mutex_lock(&acessar_deposito_caneta);
-            if (slots_disponiveis > ENVIO_MATERIA_INTERACAO)
+            if (slots_disponiveis > ENVIO_MATERIA_INTERACAO)	// Enforça parâmetro pré-definido caso haja espaço excedente
                 quant_interation = ENVIO_MATERIA_INTERACAO;
-            else
+            else												// Limita quantidade de acordo com o espaço disponível
                 quant_interation = slots_disponiveis;
 
-            if (materia_prima_disponivel < quant_interation)
+            if (materia_prima_disponivel < quant_interation)	// Limita quantidade de acordo com a matéria-prima disponível
                 quant_interation = materia_prima_disponivel;
 
-            if (quant_interation > 0 && materia_prima_disponivel > 0) // Para produzir, tem de ter espaço
+            if (quant_interation > 0 && materia_prima_disponivel > 0) // Para produzir uma quantidade n de canetas não nula há de haver espaço e matéria-prima
             {
-                sem_post(&decrementa_materiaPrima);                                      // Manda o depósito enviar a materia prima
-                pthread_cond_wait(&sinal_materia_prima, &acessar_deposito_materiaPrima); // Dá acesso ao deposito de materia prima e fica esperando o sinal para retomar o controle do estoque de materia prima
-                sem_wait(&materia_deslocada);                                            // Espera até a materia prima ser deslocada entre oo depósito e a fábrica
-                sem_post(&produza);                                                      // Assim que a materia prima chegar, começar a produzir n caneta
-                sem_wait(&producao_concluida);                                           // Controle fica esperando a produção acabar
-                sem_post(&liberar_deposito_caneta);                                      // Ao acabar a produção, manda enviar umam caneta ao deposito
-                pthread_cond_wait(&sinal_deposito_caneta, &acessar_deposito_caneta);     // libera pro deposito o acesso do deposito e fica esperando o sinal pra voltar a ter acesso ao estoque de canetas
+                sem_post(&decrementa_materiaPrima);                                      // Libera o acesso ao estoque de matéria-prima para o depósito de matéria-prima
+                pthread_cond_wait(&sinal_materia_prima, &acessar_deposito_materiaPrima); // Espera o sinal para retomar o controle do estoque de matéria-prima
+                sem_wait(&materia_deslocada);                                            // Espera até a matéria-prima ser deslocada entre o depósito e a fábrica
+                sem_post(&produza);                                                      // Assim que a matéria-prima chegar, libera a produção de n canetas
+                sem_wait(&producao_concluida);                                           // Controle espera a produção acabar
+                sem_post(&liberar_deposito_caneta);                                      // Ao acabar a produção, libera o envio de uma caneta ao depósito de canetas
+                pthread_cond_wait(&sinal_deposito_caneta, &acessar_deposito_caneta);     // Espera o sinal do depósito de canetas para voltar a ter acesso ao estoque de canetas
                 
                 // pthread_mutex_lock(&canetas_do_comprador);
                 // printf("\nControle:  | Canetas compradas: %d | Slots: %d | Matéria Prima: %d |\n", canetasCompradas, slots_disponiveis, materia_prima_disponivel);
                 // pthread_mutex_unlock(&canetas_do_comprador);
             }
-            pthread_mutex_unlock(&acessar_deposito_caneta);
-            pthread_mutex_unlock(&acessar_deposito_materiaPrima);
+            pthread_mutex_unlock(&acessar_deposito_caneta);								 // Revoga o acesso ao estoque de canetas
+            pthread_mutex_unlock(&acessar_deposito_materiaPrima);						 //	Revoga o acesso ao estoque de matéria-prima
         }
 
-        else if (slots_disponiveis < MAX_DEPOSITO_CANETA) //    Ainda tem slots, mas a materia prima acabou
+        else if (slots_disponiveis < MAX_DEPOSITO_CANETA)			// Ainda há slots, mas a matéria-prima acabou
         {
-            /*  Anteriormente usado para um controle ao vivo das variaveis. Habilitar caso o desejo de ver
+            /*  Anteriormente usado para um controle ao vivo das variaveis. Habilitar caso deseje ver
 
             pthread_mutex_lock(&acessar_deposito_materiaPrima);
             pthread_mutex_lock(&acessar_deposito_caneta);
@@ -118,10 +119,11 @@ void controle(void)
 
             pthread_mutex_unlock(&acessar_deposito_caneta);
             pthread_mutex_unlock(&acessar_deposito_materiaPrima);
+			
             */
-            pthread_cond_signal(&sinal_deposito_caneta); // libera o comprador o acesso do deposito para que compre as canetas finais do depósito
+            pthread_cond_signal(&sinal_deposito_caneta); // Libera o comprador o acesso do deposito para que compre as canetas finais do depósito
         }
-        else if (slots_disponiveis == MAX_DEPOSITO_CANETA && materia_prima_disponivel == 0) // Caso acabou os slots e a materia prima, deve acabar
+        else if (slots_disponiveis == MAX_DEPOSITO_CANETA && materia_prima_disponivel == 0) // Caso acabou os slots e a matéria-prima, deve acabar
         {
             /*  Anteriormente usado para ver a ultima interação da thread controle. Habilitar caso o desejo de ver
 
@@ -133,32 +135,33 @@ void controle(void)
             pthread_mutex_unlock(&canetas_do_comprador);
             pthread_mutex_unlock(&acessar_deposito_caneta);
             pthread_mutex_unlock(&acessar_deposito_materiaPrima);
-            printf("\n\tCódigo finalizado. Estoque de materia prima acabou e o depósito de canetas está vazioz\n");
+            printf("\n\tCódigo finalizado. Estoque de matéria-prima acabou e o depósito de canetas está vazioz\n");
 
             */
         }
     }
 }
 
-void depos_madeira(void)
+void depos_materia(void)
 {
 
     while (1) //   Variável controlada pelo criador para terminar esta thread
     {
-        sem_wait(&decrementa_materiaPrima);
+        sem_wait(&decrementa_materiaPrima);			// Aguarda acesso a quantidade de matéria-prima
 
         // pthread_mutex_lock(&acessar_deposito_materiaPrima);
 
-        pthread_mutex_lock(&acessar_deposito_materiaPrima); // Garante acecsso exclusivo ao estoque e o decrementa
-        pthread_mutex_lock(&quant_mutex);                   // Obtém a quandidade de decremento do deposito de madeira
-        materia_prima_disponivel -= quant_interation;       // Decrementa de fato
-        pthread_mutex_unlock(&quant_mutex);
-        pthread_mutex_unlock(&acessar_deposito_materiaPrima);
+        pthread_mutex_lock(&acessar_deposito_materiaPrima); 	// Obtém acesso exclusivo ao estoque
+        pthread_mutex_lock(&quant_mutex);                   	// Obtém acesso a quantidade de decremento do depósito de matéria-prima
+        materia_prima_disponivel -= quant_interation;       	// Decrementa o estoque de matéria-prima
+        pthread_mutex_unlock(&quant_mutex);						// Revoga acesso a quantidade de decremento do depósito de matéria-prima
+        pthread_mutex_unlock(&acessar_deposito_materiaPrima);	// Revoga acesso exclusivo ao estoque de matéria-prima
 
-        pthread_cond_signal(&sinal_materia_prima);
-        sleep(TEMPO_ENVIO_DEPFAB);
-        sem_post(&materia_deslocada);
-        // printf("\nDEPMAT: materia prima disponivel: %d", materia_prima_disponivel);
+        pthread_cond_signal(&sinal_materia_prima);				// Envia sinal ao controle que realizou envio de matéria-prima
+        sleep(TEMPO_ENVIO_DEPFAB);								// Dorme pelo tempo de envio
+        sem_post(&materia_deslocada);							// Libera controle para prosseguir com sinais para a produção
+		
+        // printf("\nDEPMAT: matéria-prima disponivel: %d", materia_prima_disponivel);
     }
 }
 
@@ -170,14 +173,14 @@ void celula_fabrica(void)
 
         sem_wait(&produza); //  Ao aguardo do controle para produzir
 
-        pthread_mutex_lock(&quant_mutex); //  Pegar rapidamente a quantidade de produções que será feita
+        pthread_mutex_lock(&quant_mutex); 	// Ganha acesso à quantidade n de canetas a serem fabricadas
 
         // printf("\nFAB:  Fabricando %d unidade", quant_interation);
-        for (int i = 0; i < quant_interation; i++) // fabrica n canetas garantindo a quantidade ccerta que saiu do depósito
+        for (int i = 0; i < quant_interation; i++) // Fabrica n canetas garantindo a quantidade certa que saiu do depósito
             sleep(TEMPO_PRODUCAO_CANETA);          // Tempo em que está fabricando um caneta
 
-        pthread_mutex_unlock(&quant_mutex);
-        sem_post(&producao_concluida);
+        pthread_mutex_unlock(&quant_mutex);			// Revoga acesso à quantidade n de canetas a serem fabricadas
+        sem_post(&producao_concluida);				// Termina o processo liberando a continuidade para o controle
     }
 }
 
@@ -185,16 +188,15 @@ void depos_caneta(void)
 {
     while (1) //   Variável controlada pelo criador para terminar esta thread
     {
-        sem_wait(&liberar_deposito_caneta);           //  Aguarda o controle avisar que chegou n canetas
-        pthread_mutex_lock(&quant_mutex);             //  Pegar a quantidade de produções que será feita
-        pthread_mutex_lock(&acessar_deposito_caneta); //  Garante exclusão mútua na quantidade de slots no armazém
+        sem_wait(&liberar_deposito_caneta);           		//  Aguarda o controle avisar que chegou n canetas
+        pthread_mutex_lock(&quant_mutex);             		//  Obtém a quantidade que será produzida
+        pthread_mutex_lock(&acessar_deposito_caneta); 		//  Garante exclusão mútua no acesso a quantidade de slots no depósito de canetas
 
-        slots_disponiveis -= quant_interation; //  Decrementa a quantidade de slots, agora ocupadados por n canetas
+        slots_disponiveis -= quant_interation;				//  Decrementa a quantidade de slots, agora ocupadados por n canetas
 
-        pthread_mutex_unlock(&quant_mutex);             //  Liberar acesso
-        pthread_mutex_unlock(&acessar_deposito_caneta); //  Liberar acesso
-        pthread_cond_signal(&sinal_deposito_caneta); //  Mandar o sinal para o comprador diretamente em que pode-se olha a quantidade de canetas no estoque
-
+        pthread_mutex_unlock(&quant_mutex);             	//  Revoga acesso a quantidade de canetas produzidas
+        pthread_mutex_unlock(&acessar_deposito_caneta); 	//  Revoga o acesso a quantidade de slots disponíveis no depósito de canetas
+        pthread_cond_signal(&sinal_deposito_caneta); 		//  Manda sinal para o controle prosseguir com execução
         // printf("\nDEPCAN:   quantidade de canetas no depósito são %d e slots %d", MAX_DEPOSITO_CANETA - slots_disponiveis, slots_disponiveis);
     }
 }
@@ -203,21 +205,21 @@ void comprador(void)
 {
     while (1) //   Variável controlada pelo criador para terminar esta thread
     {
-        pthread_mutex_lock(&acessar_deposito_caneta);
+        pthread_mutex_lock(&acessar_deposito_caneta);				// Ganha acesso a quantidade de canetas no depósito
         // pthread_cond_wait(&sinal_deposito_caneta, &acessar_deposito_caneta);
 
-        pthread_mutex_lock(&canetas_do_comprador);
-        int local_max = MAX_DEPOSITO_CANETA - slots_disponiveis;
+        pthread_mutex_lock(&canetas_do_comprador);					// Ganha acesso a quantidade de canetas a serem compradas
+        int local_max = MAX_DEPOSITO_CANETA - slots_disponiveis;	// Guarda a quantidade de canetas
         if (local_max > 0)
         {
             int interacao_compras;
 
-            if (local_max < COMPRA_POR_INTERACAO) //  Há menos canetas disponíveis do que o pedido
+            if (local_max < COMPRA_POR_INTERACAO) 					// Se há menos canetas disponíveis do que o pedido, restringe a quantidade compradas
                 interacao_compras = local_max;
             else
                 interacao_compras = COMPRA_POR_INTERACAO;
 
-            for (int i = 0; i < interacao_compras; i++)
+            for (int i = 0; i < interacao_compras; i++)				// Retira do estoque e compra uma caneta por vez
             {
                 slots_disponiveis++;
                 canetasCompradas++;
@@ -234,23 +236,23 @@ void comprador(void)
 int criador(void)
 {
     //  Inicializar os semáforos
-    sem_init(&decrementa_materiaPrima, 0, 0); //  Inicia o semaforo para controle de estoque de materia prima
-    sem_init(&produza, 0, 0);                 //  Inicia o semaforo para não produzindo
-    sem_init(&liberar_deposito_caneta, 0, 0); //  Inicia o semaforo para o envio das canetas
+    sem_init(&decrementa_materiaPrima, 0, 0); //  Inicia o semáforo para controle de estoque de matéria-prima
+    sem_init(&produza, 0, 0);                 //  Inicia o semáforo para não produzindo
+    sem_init(&liberar_deposito_caneta, 0, 0); //  Inicia o semáforo para o envio das canetas
 
-    //  Criação das threads
+    //  Criação das threads com atributos default e sem passagem de argumentos para sua função inicializadora
 
-    if (pthread_create(&thread_list_ID[1], 0, (void *)depos_madeira, 0) != 0)
+    if (pthread_create(&thread_list_ID[1], 0, (void *)depos_materia, 0) != 0)
     {
-        fprintf(stderr, "Erro ao criar o Célula de depósito de materia prima\n");
+        fprintf(stderr, "Erro ao criar a Célula de Depósito de Matéria-Prima\n");
     }
-    printf("\nDepósito de Madeira iniciado!");
+    printf("\nDepósito de Matéria-Prima iniciado!");
 
     if (pthread_create(&thread_list_ID[2], 0, (void *)celula_fabrica, 0) != 0)
     {
-        fprintf(stderr, "Erro ao criar o celula de fabricao de canetas\n");
+        fprintf(stderr, "Erro ao criar a Célula de Fabricação de Canetas\n");
     }
-    printf("\nCélula de Fabricação iniciado!");
+    printf("\nCélula de Fabricação iniciada!");
     if (pthread_create(&thread_list_ID[3], 0, (void *)controle, 0) != 0)
     {
         fprintf(stderr, "Erro ao criar o Controle\n");
@@ -258,7 +260,7 @@ int criador(void)
     printf("\nControle iniciado!");
     if (pthread_create(&thread_list_ID[4], 0, (void *)depos_caneta, 0) != 0)
     {
-        fprintf(stderr, "Erro ao criar o Depósito de canetas\n");
+        fprintf(stderr, "Erro ao criar o Depósito de Canetas\n");
     }
     printf("\nDepósito de Canetas iniciado!");
     if (pthread_create(&thread_list_ID[5], 0, (void *)comprador, 0) != 0)
@@ -266,44 +268,45 @@ int criador(void)
         fprintf(stderr, "Erro ao criar o Comprador\n");
     }
     printf("\nComprador iniciado!");
-    int contador_canetas = 0;
-    while (contador_canetas < MAX_MATERIA_PRIMA)
+    int contador_canetas = 0;			// Canetas compradas totais
+	
+    while (contador_canetas < MAX_MATERIA_PRIMA)						// Enquanto a matéria-prima for suficiente para fabricar as canetas necessárias
     {
-        pthread_mutex_lock(&canetas_do_comprador);
-        pthread_cond_wait(&sinal_ao_criador, &canetas_do_comprador);
-        if (canetasCompradas > contador_canetas)
+        pthread_mutex_lock(&canetas_do_comprador);						// Ganha acesso a quantidade de canetas compradas nesta iteração
+        pthread_cond_wait(&sinal_ao_criador, &canetas_do_comprador);	// Espera o sinal que o comprador tentou/concluiu uma compra
+        if (canetasCompradas > contador_canetas)						
         {
-
+			// Atualiza na tela as compras feitas nesta iteração
             printf("\nComprador comprou %2.d canetas nesta interação e o total já comprado é: %2.d", canetasCompradas - contador_canetas, canetasCompradas);
             fflush(stdout);
-            contador_canetas = canetasCompradas;
+            contador_canetas = canetasCompradas;						// Atualiza na memória a quantidade de compras feitas até aqui
         }
         else if (canetasCompradas == contador_canetas)
         {
             printf("\nNão houve compra nessa interação");
             fflush(stdout);
         }
-        pthread_mutex_unlock(&canetas_do_comprador);
+        pthread_mutex_unlock(&canetas_do_comprador);					// Revoga acesso a quantidade de canetas nesta iteração
     }
     printf("\n\n-- -- -- -- Compra finalizada com sucesso!!-- -- -- -- \n");
 
-    //  Finalizar os semáforos
+    //  Finaliza os semáforos
     sem_destroy(&decrementa_materiaPrima);
     sem_destroy(&produza);
     sem_destroy(&liberar_deposito_caneta);
 
-    //  Finalizar os mutexes
+    //  Finaliza os mutexes
     pthread_mutex_destroy(&canetas_do_comprador);
     pthread_mutex_destroy(&quant_mutex);
     pthread_mutex_destroy(&acessar_deposito_caneta);
     pthread_mutex_destroy(&acessar_deposito_materiaPrima);
 
-    //  Finalizar as variáveis de condição
+    //  Finaliza as variáveis de condição
     pthread_cond_destroy(&sinal_materia_prima);
     pthread_cond_destroy(&sinal_deposito_caneta);
     pthread_cond_destroy(&sinal_ao_criador);
 
-    //   não foi dado join em nenhuma thread, pois basta o comprador ter comprado tudo que o programa pode ser finalizado com sucesso.
+    //  Não foi dado join em nenhuma thread, pois basta o comprador ter comprado tudo que o programa pode ser finalizado com sucesso.
     return 0;
 }
 


### PR DESCRIPTION
**Mudanças**

271 	adicionado comentários sobre funcionalidade da região crítica do criador

145/245  alterado nome de função depos_madeira pra depos_materia 

148	adicionado comentários sobre funcionalidade da região crítica do depos_materia

189	complementado comentários sobre funcionalidade da região crítica do depósito de canetas

199  mudança no comentário: sinal_deposito_caneta não é mais enviado a comprador

98	mudança no comentário: pthread_cond_wait apenas espera pelo sinal do depósito de canetas

203 	adicionado comentários sobre funcionalidade da região crítica do comprador

correções de grafia nos comentários sem mudar sentido




**Sugestão de Mudanças / Dúvidas**

124	comentar/remover linha pois se não entrou no primeiro if não há ninguém esperando por sinal_deposito_caneta, talvez faça sentido junto com as linhas de código comentadas em cima
		
245-266	alterar pthread_create(&thread_list_ID[i], 0, (void *){nomedafuncao}, 0) para pthread_create(&thread_list_ID[i], NULL, (void *){nomedafuncao}, NULL) dado que const pthread_attr_t *attr e void *arg são ponteiros